### PR TITLE
fix: toast prop 타입 오류 및 off 동작 버그 수정 (#12)

### DIFF
--- a/packages/copymark/src/hooks/useCopyValue.ts
+++ b/packages/copymark/src/hooks/useCopyValue.ts
@@ -15,15 +15,16 @@ export function useCopyValue(options: UseCopyValueOptions = {}) {
     duration = 2000,
     theme,
     messages,
-    toast = "on",
+    toast = true,
   } = options;
 
   const mergedMessages = { ...DEFAULT_MESSAGES, ...(messages ?? {}) };
 
+  const toastDisabled = toast === false || toast === "off";
+
   const { copy, status, lastResult, reset } = useCopymark({
     onResult: (r) => {
-      // toast 설정이 "off"면 중단
-      if (toast === "off") return;
+      if (toastDisabled) return;
 
 
 

--- a/packages/copymark/src/types/hooks.ts
+++ b/packages/copymark/src/types/hooks.ts
@@ -20,11 +20,11 @@ export type CopyToastMessages = {
 export type UseCopyValueOptions = {
   /**
    * 토스트 표시 설정
-   * - "on": 토스트 활성화 (Provider가 없으면 자동으로 생성)
-   * - "off": 토스트 비활성화
-   * @default "on"
+   * - 기본값: 토스트 활성화
+   * - false 또는 "off": 토스트 비활성화
+   * @default true
    */
-  toast?: "on" | "off";
+  toast?: boolean | "off";
   /**
    * 토스트 테마
    * @default "grass"


### PR DESCRIPTION
## Summary
- `toast="off"` 또는 `toast={false}` 를 넘겨도 토스트가 뜨던 버그 수정
- toast prop 타입을 `boolean | "off"` 로 정리하여 직관적인 API로 개선

## Related Issue
closes #12

## Root Cause
toast 타입이 `"on" | "off"` 였는데 website에서 `boolean`을 넘기고 있었음.
`useCopyValue`의 off 판별이 `=== "off"` 만 체크하여 `false` 를 무시 → 항상 토스트 출력.

## Changes
- `packages/copymark/src/types/hooks.ts`
  - `toast?: "on" | "off"` → `toast?: boolean | "off"`
- `packages/copymark/src/hooks/useCopyValue.ts`
  - default `"on"` → `true`
  - `if (toast === "off")` → `if (toast === false || toast === "off")`

## New API
| prop | 결과 |
|---|---|
| (없음) | 토스트 ON (기본값) |
| `toast` | 토스트 ON |
| `toast={true}` | 토스트 ON |
| `toast={false}` | 토스트 OFF |
| `toast="off"` | 토스트 OFF |

## QA Checklist
- [x] `npm --workspace website run lint` 통과
- [x] `npm --workspace website run format:check` 통과
- [x] 브라우저에서 toast ON/OFF 동작 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)